### PR TITLE
Change initialize_all_variables to global_variables_initializer

### DIFF
--- a/common/benchmark.py
+++ b/common/benchmark.py
@@ -25,7 +25,7 @@ def benchmark(game_spec, network_file_path, create_network_func, log_games=False
     input_layer, output_layer, variables = create_network_func()
 
     with tf.Session() as session:
-        session.run(tf.initialize_all_variables())
+        session.run(tf.global_variables_initializer())
         load_network(session, variables, network_file_path)
 
         def make_move(board_state, side):

--- a/techniques/train_policy_gradient.py
+++ b/techniques/train_policy_gradient.py
@@ -50,7 +50,7 @@ def train_policy_gradients(game_spec,
     train_step = tf.train.AdamOptimizer(learn_rate).minimize(-policy_gradient)
 
     with tf.Session() as session:
-        session.run(tf.initialize_all_variables())
+        session.run(tf.global_variables_initializer())
 
         if network_file_path and os.path.isfile(network_file_path):
             print("loading pre-existing network")

--- a/techniques/train_policy_gradient_historic.py
+++ b/techniques/train_policy_gradient_historic.py
@@ -58,7 +58,7 @@ def train_policy_gradients_vs_historic(game_spec, create_network, network_file_p
         historical_networks.append((historical_input_layer, historical_output_layer, historical_variables))
 
     with tf.Session() as session:
-        session.run(tf.initialize_all_variables())
+        session.run(tf.global_variables_initializer())
 
         def make_move_historical(histoical_network_index, board_state, side):
             net = historical_networks[histoical_network_index]

--- a/techniques/train_supervised.py
+++ b/techniques/train_supervised.py
@@ -59,7 +59,7 @@ def train_supervised(game_spec, create_network, network_file_path,
     accuracy = tf.reduce_mean(tf.cast(correct_pred, tf.float32))
 
     with tf.Session() as session:
-        session.run(tf.initialize_all_variables())
+        session.run(tf.global_variables_initializer())
 
         if os.path.isfile(network_file_path):
             print("loading existing network")

--- a/techniques/train_value_network.py
+++ b/techniques/train_value_network.py
@@ -45,7 +45,7 @@ def train_value_network(game_spec, hidden_nodes_reinforcement, reinforcement_net
     train_step = tf.train.RMSPropOptimizer(learn_rate).minimize(error)
 
     with tf.Session() as session:
-        session.run(tf.initialize_all_variables())
+        session.run(tf.global_variables_initializer())
 
         load_network(session, reinforcement_variables, reinforcement_network_file_path)
 

--- a/tests/common/test_network_helpers.py
+++ b/tests/common/test_network_helpers.py
@@ -33,7 +33,7 @@ class TestNetworkHelpers(TestCase):
             _, _, variables2 = create_network(input_nodes, hidden_nodes)
 
             with tf.Session() as session:
-                session.run(tf.initialize_all_variables())
+                session.run(tf.global_variables_initializer())
 
                 save_network(session, variables1, file_name)
                 load_network(session, variables2, file_name)
@@ -55,7 +55,7 @@ class TestNetworkHelpers(TestCase):
             _, _, variables2 = create_network(input_nodes, (40, ))
 
             with tf.Session() as session:
-                session.run(tf.initialize_all_variables())
+                session.run(tf.global_variables_initializer())
 
                 save_network(session, variables1, file_name)
 

--- a/value_network.py
+++ b/value_network.py
@@ -61,7 +61,7 @@ error = tf.reduce_sum(tf.square(target_placeholder - value_output_layer))
 train_step = tf.train.RMSPropOptimizer(LEARN_RATE).minimize(error)
 
 with tf.Session() as session:
-    session.run(tf.initialize_all_variables())
+    session.run(tf.global_variables_initializer())
 
     load_network(session, reinforcement_variables, REINFORCEMENT_NETWORK_PATH)
 


### PR DESCRIPTION
initialize_all_variables (from tensorflow.python.ops.variables) is deprecated

Signed-off-by: Taeho Lee <smartdolphin07@gmail.com>